### PR TITLE
build: bump Go toolchain to 1.27

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.x"]
+        go-version: ["^1.27"]
     steps:
       - uses: actions/checkout@v4.1.7
       - name: Set up Go ${{ matrix.go-version }}
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
-          go-version: ^1.20
+          go-version: ^1.27
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.7.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
-          go-version: ^1.20
+          go-version: ^1.27
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5 # https://github.com/marketplace/actions/goreleaser-action

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/danstis/toggl-taskbar
 
-go 1.20
+go 1.27
 
 require (
 	fyne.io/systray v1.10.0


### PR DESCRIPTION
### **User description**
## Summary

Pin the Go toolchain to the current `^1.27` stream and align `go.mod`. The previous `^1.20` floor was already resolving to Go 1.24+ at runtime, which left the **Lint** job failing on type-check errors against transitive deps that target newer Go versions (see #135 run [32791175114](https://github.com/danstis/toggl-taskbar/actions/runs/32791175114/job/97632883612)).

This is the workflow-only half of the fix; the SonarCloud `JRE metadata` failure in the same run needs a separate change to `SonarSource/sonarcloud-github-action@master` (deprecated; see [upstream notice](https://github.com/SonarSource/sonarcloud-github-action)).

## Changes

- `.github/workflows/build.yml`: build matrix `go-version: ["1.x"]` → `["^1.27"]`
- `.github/workflows/build.yml`: lint job `go-version: ^1.20` → `^1.27`
- `.github/workflows/release.yml`: release job `go-version: ^1.20` → `^1.27`
- `go.mod`: `go 1.20` → `go 1.27` (kept the lower bound at the new floor; no new deps added)

## Why `^1.27` (not `1.x`)

Resolves to a known-stable release (1.27.0, 18 Aug 2026) rather than the bleeding edge of the `1.x` stream, while still picking up future 1.27.x patch releases automatically.

## Verification

- Local clone builds clean against `go 1.27`.
- Workflow run after merge should resolve `go-version: ^1.27` to `go1.27.x` on the runner and clear the `undefined: resty (typecheck)` and `file requires newer Go version go1.26` errors.

## Follow-up

- [ ] Investigate the SonarCloud `Failed to query JRE metadata` failure separately (deprecated `@master` action + possibly migrated project key on sonarcloud.io).
- [ ] Consider accepting #122 / #134 to bump `golangci/golangci-lint-action` to v6 once this lands.


___

### **PR Type**
Enhancement


___

### **Description**
- Bump Go toolchain floor from `^1.20` to `^1.27`

- Update `go.mod` go directive to `1.27`

- Update build matrix and lint job Go version in `build.yml`

- Update release job Go version in `release.yml`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  goMod["go.mod: go 1.20"] -- "bump" --> goModNew["go.mod: go 1.27"]
  buildYml["build.yml: go-version 1.x / ^1.20"] -- "bump" --> buildYmlNew["build.yml: go-version ^1.27"]
  releaseYml["release.yml: go-version ^1.20"] -- "bump" --> releaseYmlNew["release.yml: go-version ^1.27"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.mod</strong><dd><code>Bump go directive to 1.27</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go.mod

<ul><li>Updated the <code>go</code> directive from <code>1.20</code> to <code>1.27</code> to align with the current <br>stable toolchain.</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/toggl-taskbar/pull/137/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build.yml</strong><dd><code>Pin build and lint jobs to Go ^1.27</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/build.yml

<ul><li>Changed test job matrix <code>go-version</code> from <code>"1.x"</code> to <code>"^1.27"</code>.<br> <li> Changed lint job <code>go-version</code> from <code>^1.20</code> to <code>^1.27</code> to fix type-check <br>errors.</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/toggl-taskbar/pull/137/files#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Bump release job Go version to ^1.27</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>Updated release job <code>go-version</code> from <code>^1.20</code> to <code>^1.27</code> to match new <br>toolchain floor.</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/toggl-taskbar/pull/137/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

