### PR TITLE
build: track Go version pins in workflow files via Renovate regex manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,17 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "regexManagers": [
+    {
+      "description": "Track Go version pin in actions/setup-go inputs",
+      "fileMatch": ["^\\.github/workflows/[^/]+\\.ya?ml$"],
+      "matchStrings": [
+        "go-version:\\s*\\^?(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)\\s*[\"']?\\s*(#.*)?$",
+        "go-version:\\s*\\[\"\\^?(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)\"\\]\\s*(#.*)?$"
+      ],
+      "datasourceTemplate": "golang-version",
+      "depNameTemplate": "go"
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -3,13 +3,14 @@
   "extends": [
     "config:recommended"
   ],
-  "regexManagers": [
+  "customManagers": [
     {
+      "customType": "regex",
       "description": "Track Go version pin in actions/setup-go inputs",
-      "fileMatch": ["^\\.github/workflows/[^/]+\\.ya?ml$"],
+      "managerFilePatterns": ["^\\.github/workflows/[^/]+\\.ya?ml$"],
       "matchStrings": [
-        "go-version:\\s*\\^?(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)\\s*[\"']?\\s*(#.*)?$",
-        "go-version:\\s*\\[\"\\^?(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)\"\\]\\s*(#.*)?$"
+        "(?:^|\\r\\n|\\r|\\n)\\s*go-version:\\s*[\"\\']?\\^?(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)[\"\\']?\\s*(?:#.*)?(?:$|\\r\\n|\\r|\\n)",
+        "(?:^|\\r\\n|\\r|\\n)\\s*go-version:\\s*\\[\\s*\"\\^?(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)\"\\s*\\]\\s*(?:#.*)?(?:$|\\r\\n|\\r|\\n)"
       ],
       "datasourceTemplate": "golang-version",
       "depNameTemplate": "go"


### PR DESCRIPTION
### **User description**
## Summary

Make Renovate track the Go version pin in workflow `go-version:` inputs so the workflow and `go.mod` stay in lockstep going forward.

Without this, the built-in `github-actions` manager only tracks the `actions/setup-go` action version — it does not understand that `go-version: ^1.27` is a Go version reference. Renovate would silently skip updating the string, leaving the workflow pinned at whatever version it was hand-bumped to.

## Why both patterns

The repo uses two forms of `go-version` input:

1. Scalar: `go-version: ^1.27` (build.yml lint job, release.yml release job)
2. Matrix:  `go-version: ["^1.27"]` (build.yml build/test matrix)

A single regex doesn't cleanly cover both without false positives on the `go-version: ${{ matrix.go-version }}` re-reference line, so the regex manager declares two `matchStrings`. Both share the `golang-version` datasource and `depName: go`.

## What Renovate will now do

- On every Renovate run, compare `^1.27` in each workflow against the latest `golang-version` release in the `1.27` minor stream.
- Open a PR like `chore(deps): update go to ^1.27.5` whenever a new patch release ships, and `^1.28` whenever a new minor ships.
- `go.mod` is already tracked by the built-in `gomod` manager — both will be updated in lockstep (Renovate groups updates per package).

## Verification

- Regex was unit-tested locally against every existing `go-version:` line in the repo (matrix, scalar, quoted, unquoted, with/without caret, with trailing comment).
- The `${{ matrix.go-version }}` re-reference line is correctly excluded (it contains no literal version string).
- The `["1.x"]` bare-string matrix form is excluded (no digit.digit pattern).

## Out of scope

- `.github/dependabot.yml` also tracks `gomod` and `github-actions`. Both bots run independently; this change only affects Renovate. If you want to avoid double-PRs for Go module bumps, that's a separate decision (disable Dependabot's `gomod` ecosystem, or set `open-pull-requests-limit: 0`).


___

### **PR Type**
Enhancement


___

### **Description**
- Add Renovate regexManager for Go version pins

- Tracks `go-version:` in workflow files

- Covers scalar and matrix-bracket forms

- Uses `golang-version` datasource with `depName: go`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["renovate.json"] -- "adds regexManagers" --> B["workflow go-version pins"]
  B -- "matched against" --> C["golang-version datasource"]
  C -- "keeps in sync with" --> D["go.mod (gomod manager)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>renovate.json</strong><dd><code>Add regexManager for Go version pins in workflows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

renovate.json

<ul><li>Added a <code>regexManagers</code> entry to track Go version pins<br> <li> Matches <code>go-version:</code> scalar form (e.g. <code>^1.27</code>)<br> <li> Matches <code>go-version:</code> matrix-bracket form (e.g. <code>["^1.27"]</code>)<br> <li> Uses <code>golang-version</code> datasource and <code>depName: go</code> to resolve updates</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/toggl-taskbar/pull/140/files#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

