### PR TITLE
build: disable Dependabot version-update PRs in favor of Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,16 +2,23 @@
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
 # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates
+#
+# Note: open-pull-requests-limit: 0 is set on every ecosystem so Dependabot
+# does not open PRs. Renovate (configured in /renovate.json) owns all version
+# updates for this repo, including go modules, GitHub Actions, and the Go
+# version pin in workflow go-version inputs.
 
 version: 2
 updates:
-  # Update go modules
-  - package-ecosystem: "gomod" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  # Update go modules (Dependabot disabled; Renovate owns this)
+  - package-ecosystem: "gomod"
+    directory: "/"
     schedule:
       interval: "daily"
-  # Maintain dependencies for GitHub Actions
+    open-pull-requests-limit: 0
+  # Maintain dependencies for GitHub Actions (Dependabot disabled; Renovate owns this)
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
### **User description**
## Summary

Stop Dependabot from opening version-update PRs. Renovate now owns all dependency bumps for this repo.

## What changed

`.github/dependabot.yml`:
- `gomod` ecosystem → `open-pull-requests-limit: 0`
- `github-actions` ecosystem → `open-pull-requests-limit: 0`
- Inline comment documenting that Renovate owns updates

## Why

Both bots were running in parallel and competing for the same dependency bumps. The repo's Renovate config covers everything Dependabot was doing:

| Bump type | Manager |
|-----------|---------|
| Go module updates | Renovate `gomod` (built-in) |
| `actions/*` version bumps | Renovate `github-actions` (built-in) |
| `go-version:` input value in workflows | Renovate regex manager (added in #140) |
| Go version `go.mod` directive | Renovate `gomod` (built-in) |

With `open-pull-requests-limit: 0`, Dependabot will scan manifests but never open a PR. Renovate handles all version updates.

## What still works

- **Dependabot security alerts** on the Security tab — unaffected. Dependabot still scans `go.mod` and `.github/workflows/*.yml` for vulnerable versions, just doesn't auto-remediate via PR.
- **Dependabot pull_request and issue creation** — also unaffected if you want to add them back later.

## Verification

After this merges, the open Dependabot PRs (#133, #130, #122, #121, #113) will still be open and can be merged/closed individually. No new Dependabot PRs will appear. Renovate continues to produce its own PRs as usual.

If you want the existing 5 Dependabot PRs closed too, say the word and I'll close them with a comment explaining why (they're superseded by Renovate-managed updates).


___

### **PR Type**
Enhancement


___

### **Description**
- Disable Dependabot PRs on all ecosystems

- Set `open-pull-requests-limit: 0` for `gomod` and `github-actions`

- Add comments documenting Renovate as sole update owner


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[".github/dependabot.yml"] -- "sets limit 0 on" --> B["gomod ecosystem"]
  A -- "sets limit 0 on" --> C["github-actions ecosystem"]
  D["Renovate (renovate.json)"] -- "now owns" --> B
  D -- "now owns" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependabot.yml</strong><dd><code>Disable Dependabot PRs, defer to Renovate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/dependabot.yml

<ul><li>Added <code>open-pull-requests-limit: 0</code> to <code>gomod</code> ecosystem config<br> <li> Added <code>open-pull-requests-limit: 0</code> to <code>github-actions</code> ecosystem config<br> <li> Added header and inline comments documenting that Renovate now owns <br>all version updates</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/toggl-taskbar/pull/141/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28">+11/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

